### PR TITLE
feat(fluentd/upgrade): Upgrade fluentd version and maintain plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
+.idea
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.8-debian-forward-1
-RUN fluent-gem install fluent-plugin-datadog
+FROM fluent/fluentd-kubernetes-daemonset:v1.16-debian-forward-1
+RUN fluent-gem install fluent-plugin-parser-cri --no-document
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Fluentd
 
-A small image that adds the [DataDog Fluentd plugin](https://github.com/DataDog/fluent-plugin-datadog)
+A small image that adds the [Fluentd CRI Parser plugin](https://github.com/fluent/fluent-plugin-parser-cri)
 to the [Kubernetes Daemonset Fluentd forwarder image](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset).


### PR DESCRIPTION
Upgrade to fluentd 1.16, add the CRI parser to handle the upgrade to Kubernetes 1.24, and remove the DataDog plugin since we do not use it.