### PR TITLE
feat(newrelic-plugin): Need the newrelic plugin now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM fluent/fluentd-kubernetes-daemonset:v1.16-debian-forward-1
 RUN fluent-gem install fluent-plugin-parser-cri --no-document
+RUN fluent-gem install fluent-plugin-newrelic
 


### PR DESCRIPTION
Earlier version apparently had newrelic plugin by default, or it was not committed to this repository.